### PR TITLE
fix: 유저 정보 관련 API 보안 강화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.sw?
 
 .env
+.env.production
+.env.development

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.2",
     "firebase-admin": "^10.0.2",
-    "firebase-functions": "^3.18.0"
+    "firebase-functions": "^3.18.0",
+    "moment-timezone": "^0.5.40"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/functions/src/answers.ts
+++ b/functions/src/answers.ts
@@ -1,8 +1,9 @@
 import * as admin from "firebase-admin";
 import * as express from "express";
 import * as cors from "cors";
+import * as moment from "moment-timezone";
 import { Answer, Option, Question } from "./@types";
-import { getAdminApp, https } from "./common";
+import { getAdminApp, getProperty, https, toMap } from "./common";
 import { DocumentReference } from "firebase/firestore";
 import { checkUserIdContained } from "./middleware";
 
@@ -90,31 +91,68 @@ const convertDocsToAnswers = async (
   return answers.sort((a, b) => b.createdAt - a.createdAt);
 };
 
+const calcAgeGroup = (birthdate: number) => {
+  const year = moment.tz(birthdate, "Asia/Seoul").year();
+  const currentYear = moment().tz("Asia/Seoul").year();
+  const age = currentYear - year + 1;
+  return age.toString().slice(0, 1) + "0";
+};
+
 app.get("/", checkUserIdContained, async (req, res) => {
   try {
     const app = getAdminApp();
     const db = admin.firestore(app);
 
-    const { user: userId } = req.query;
+    const { user: userId, question: questionId, groups } = req.query;
+
+    const { empty, docs } = await db.collection("answers").get();
+    if (empty) {
+      return res.status(204).json();
+    }
+    const answers = await convertDocsToAnswers(db, docs);
 
     if (userId) {
       if (userId === req.body.uid) {
-        const { empty, docs } = await db
-          .collection("answers")
-          .where("user.id", "==", userId)
-          .get();
-        if (empty) {
+        const filteredAnswers = answers.filter(
+          (answer) => answer.user.id === userId
+        );
+        if (filteredAnswers.length === 0) {
           return res.status(204).json();
         }
-        const answers = await convertDocsToAnswers(db, docs);
-        return res.status(200).json(answers);
+        return res.status(200).json(filteredAnswers);
       }
       return res
         .status(403)
         .json({ code: 403, message: "사용자 인증에 실패하였습니다." });
     }
 
-    return res.status(204).json();
+    if (groups && Array.isArray(groups)) {
+      const filteredAnswers = questionId
+        ? answers.filter((answer) => answer.question.id === questionId)
+        : answers;
+      if (filteredAnswers.length === 0) {
+        return res.status(204).json();
+      }
+
+      const result = (groups as string[]).reduce((acc, groupKey) => {
+        const keyGetter = (answer: ReturnAnswer) => {
+          const key = getProperty(answer, groupKey);
+          return groupKey.match(/birthdate/) ? calcAgeGroup(key) : key;
+        };
+        const group = toMap(
+          filteredAnswers,
+          keyGetter,
+          (answer) => answer.option
+        );
+        return { ...acc, [groupKey]: Object.fromEntries(group) };
+      }, {});
+
+      return res.status(200).json(result);
+    }
+
+    return res
+      .status(400)
+      .json({ code: 400, message: "전체 답변은 불러올 수 없습니다." });
   } catch (error) {
     return res.status(500).json(error);
   }

--- a/functions/src/answers.ts
+++ b/functions/src/answers.ts
@@ -9,11 +9,6 @@ import { checkUserIdContained } from "./middleware";
 const app = express();
 app.use(cors({ origin: true }));
 
-type QueryParams = {
-  user?: string;
-  question?: string;
-  date?: string;
-};
 type ReturnAnswer = {
   id: string;
   user: Answer["user"];
@@ -21,72 +16,6 @@ type ReturnAnswer = {
   option: { id: string } & Option;
   createdAt: number;
 };
-
-const createPredicate = (queryParams: QueryParams) => {
-  const { user, question, date } = queryParams;
-
-  const pred = (answer: ReturnAnswer) => {
-    const results = [];
-    if (user) {
-      results.push(answer.user.id === user);
-    }
-    if (question) {
-      results.push(answer.question.id === question);
-    }
-    if (date) {
-      results.push(answer.question.createdAt === date);
-    }
-    return results.every((v) => v);
-  };
-
-  return pred;
-};
-
-app.get("/", async (req, res) => {
-  try {
-    const app = getAdminApp();
-    const db = admin.firestore(app);
-
-    const { empty, docs } = await db.collection("answers").get();
-    if (empty) {
-      return res.status(204).json([]);
-    }
-
-    const answersPromise = docs.map(async (doc) => {
-      const answer = doc.data() as Answer;
-      const question = await db.doc("questions/" + answer.question.id).get();
-      const option = await db.doc("options/" + answer.option.id).get();
-
-      const converted: ReturnAnswer = {
-        ...answer,
-        id: doc.id,
-        question: { id: question.id, ...(question.data() as Question) },
-        option: { id: option.id, ...(option.data() as Option) },
-      };
-      return converted;
-    });
-
-    const answers = (await Promise.allSettled(answersPromise)).reduce(
-      (acc: ReturnAnswer[], result) =>
-        result.status === "fulfilled" ? [...acc, result.value] : acc,
-      []
-    );
-
-    const pred = createPredicate(req.query);
-    const filteredAnswers = answers
-      .filter(pred)
-      .sort((a, b) => b.createdAt - a.createdAt);
-
-    if (filteredAnswers.length === 0) {
-      return res.status(204).json([]);
-    } else {
-      return res.status(200).json(filteredAnswers);
-    }
-  } catch (error) {
-    console.log(error);
-    return res.status(500).json(error);
-  }
-});
 
 app.get("/:id", async (req, res) => {
   try {
@@ -138,12 +67,15 @@ const convertDocsToAnswers = async (
   const answersPromise = docs.map(async (doc) => {
     const answer = doc.data() as Answer;
     const question = await db.doc("questions/" + answer.question.id).get();
+    const options = question
+      .get("options")
+      .map((doc: DocumentReference) => doc.id);
     const option = await db.doc("options/" + answer.option.id).get();
 
     const converted: ReturnAnswer = {
       ...answer,
       id: doc.id,
-      question: { id: question.id, ...(question.data() as Question) },
+      question: { id: question.id, ...(question.data() as Question), options },
       option: { id: option.id, ...(option.data() as Option) },
     };
     return converted;

--- a/functions/src/auth.ts
+++ b/functions/src/auth.ts
@@ -124,9 +124,9 @@ app.post("/kakao", async (req, res) => {
     const app = getAdminApp();
     const auth = admin.auth(app);
     const authUser = await updateOrCreateUser(auth, normalizedUser);
-    const firebaseToken = await admin
-      .auth()
-      .createCustomToken(authUser.uid, { KAKAO_PROVIDER });
+    const firebaseToken = await auth.createCustomToken(authUser.uid, {
+      KAKAO_PROVIDER,
+    });
 
     const db = admin.firestore(app);
     const user = await db.doc("users/" + authUser.uid).get();

--- a/functions/src/common.ts
+++ b/functions/src/common.ts
@@ -17,3 +17,34 @@ export const getAdminApp = () => {
 
   return app;
 };
+
+export const getProperty = <T extends Record<string, any>>(
+  obj: T,
+  path: string
+): any => {
+  return path
+    .split(".")
+    .reduce(
+      (acc, key) => (acc && acc[key] !== undefined ? acc[key] : undefined),
+      obj
+    );
+};
+
+export const toMap = <K, V>(
+  arr: Array<V>,
+  keyGetter: (item: V) => K,
+  valueGetter: (item: V) => any
+) => {
+  const map = new Map<K, any>();
+  arr.forEach((item) => {
+    const key = keyGetter(item);
+    const value = valueGetter(item);
+    const collection = map.get(key);
+    if (!collection) {
+      map.set(key, [value]);
+    } else {
+      collection.push(value);
+    }
+  });
+  return map;
+};

--- a/functions/src/middleware/index.ts
+++ b/functions/src/middleware/index.ts
@@ -1,0 +1,61 @@
+import * as admin from "firebase-admin";
+import * as express from "express";
+import { getAdminApp } from "../common";
+
+export const checkToken: express.RequestHandler = async (req, res, next) => {
+  try {
+    const token = req.headers.authorization?.split("Bearer ")[1];
+
+    if (!token) {
+      return res
+        .status(403)
+        .json({ code: 403, message: "No credentials sent!" });
+    }
+
+    const app = getAdminApp();
+    const auth = admin.auth(app);
+
+    const { uid } = await auth.verifyIdToken(token);
+    req.body.uid = uid;
+
+    return next();
+  } catch (error) {
+    return res
+      .status(403)
+      .json({ code: 403, message: "사용자 인증에 실패하였습니다." });
+  }
+};
+
+export const checkFields: express.RequestHandler = (req, res, next) => {
+  try {
+    const { fields } = req.query;
+    if (typeof fields === "string" && Array.isArray(JSON.parse(fields))) {
+      const fieldStringList = JSON.parse(fields) as string[];
+      const isAuthRequired =
+        fieldStringList.includes("id") || fieldStringList.includes("email");
+      if (isAuthRequired) {
+        return checkToken(req, res, next);
+      }
+    }
+    return next();
+  } catch (error) {
+    console.log(error);
+    return res.status(500).json(error);
+  }
+};
+
+export const checkUserIdContained: express.RequestHandler = (
+  req,
+  res,
+  next
+) => {
+  try {
+    const userId = req.query.user;
+    if (typeof userId === "string") {
+      return checkToken(req, res, next);
+    }
+    return next();
+  } catch (error) {
+    return res.status(500).json(error);
+  }
+};

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -7,25 +7,33 @@ const app = express();
 app.use(cors({ origin: true }));
 
 const checkToken: express.RequestHandler = async (req, res, next) => {
-  const token = req.headers.authorization?.split("Bearer ")[1];
+  try {
+    const token = req.headers.authorization?.split("Bearer ")[1];
 
-  if (!token) {
-    return res.status(403).json({ code: 403, message: "No credentials sent!" });
-  }
+    if (!token) {
+      return res
+        .status(403)
+        .json({ code: 403, message: "No credentials sent!" });
+    }
 
-  const app = getAdminApp();
-  const auth = admin.auth(app);
+    const app = getAdminApp();
+    const auth = admin.auth(app);
 
-  const { uid } = await auth.verifyIdToken(token);
-  const { id } = req.params;
+    const { uid } = await auth.verifyIdToken(token);
+    const { id } = req.params;
 
-  if (uid !== id) {
+    if (uid !== id) {
+      return res
+        .status(403)
+        .json({ code: 403, message: "사용자 인증에 실패하였습니다." });
+    }
+
+    return next();
+  } catch (error) {
     return res
       .status(403)
       .json({ code: 403, message: "사용자 인증에 실패하였습니다." });
   }
-
-  return next();
 };
 
 const createQuery = (

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -2017,6 +2017,18 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+moment-timezone@^0.5.40:
+  version "0.5.40"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.40.tgz#c148f5149fd91dd3e29bf481abc8830ecba16b89"
+  integrity sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0":
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tailwindcss": "^3.1.8"
   },
   "devDependencies": {
+    "@types/node": "^18.11.16",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
     "@vitejs/plugin-react": "^2.1.0",

--- a/src/@types/Answer.ts
+++ b/src/@types/Answer.ts
@@ -1,14 +1,10 @@
 import { Option } from "./Option";
+import { Question } from "./Question";
 import { User } from "./User";
 
 export interface Answer {
   id: string;
   user: User;
-  question: {
-    id: string;
-    createdAt: string;
-    options: [Option];
-    title: string;
-  };
+  question: Question;
   option: Option;
 }

--- a/src/@types/Auth.ts
+++ b/src/@types/Auth.ts
@@ -3,4 +3,5 @@ import { NormalizedUser } from "./User";
 export interface Auth {
   firebaseToken: string;
   kakaoUser: NormalizedUser;
+  isJoined: boolean;
 }

--- a/src/@types/react-app-env.d.ts
+++ b/src/@types/react-app-env.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    Kakao: any;
+  }
+}

--- a/src/common/apis.ts
+++ b/src/common/apis.ts
@@ -82,22 +82,28 @@ export const answer = (questionId: string, optionId: string) => {
   });
 };
 
-export const getAnswers = async (params?: {
-  user?: string;
-  question?: string;
-  date?: string;
-}): Promise<AxiosResponse<Answer[]>> => {
+type GetAnswersParams =
+  | { user: string; token: string; question?: undefined }
+  | { question: string; user?: undefined; token?: undefined };
+
+export const getAnswers = async (
+  params?: GetAnswersParams
+): Promise<AxiosResponse<Answer[]>> => {
+  if (params && params.user) {
+    return axios.get("/api/answers", {
+      params: {
+        user: params.user,
+      },
+      headers: {
+        Authorization: `Bearer ${params.token}`,
+      },
+    });
+  }
   return axios.get("/api/answers", { params });
 };
 
 export const getAnswer = (answerId: string): Promise<AxiosResponse<Answer>> => {
   return axios.get("/api/answers/" + answerId);
-};
-
-export const getAnswerCount = async () => {
-  const user = getCurrentUserId();
-  const answers = await getAnswers({ user });
-  return answers.data.length;
 };
 
 export const getOptions = (params?: {

--- a/src/common/apis.ts
+++ b/src/common/apis.ts
@@ -21,20 +21,39 @@ export const createUser = (user: User) => {
   return axios.post("/api/users/" + user.id, { ...user });
 };
 
-export const getUser = async (id: string): Promise<User | null> => {
-  const res = await axios.get("/api/users/" + id);
+export const getUser = async (
+  id: string,
+  token: string
+): Promise<User | null> => {
+  const res = await axios.get("/api/users/" + id, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
   if (res.status === 204) {
     return null;
   }
   return res.data;
 };
 
-export const updateUser = (id: string, data: UpdateData<User>) => {
-  return axios.patch("/api/users/" + id, { ...data });
+export const updateUser = (
+  id: string,
+  token: string,
+  data: UpdateData<User>
+) => {
+  return axios.patch(
+    "/api/users/" + id,
+    { ...data },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
 };
 
-export const deleteUser = async () => {
-  return axios.delete("/api/users/" + getCurrentUserId());
+export const deleteUser = async (token: string) => {
+  return axios.delete("/api/users/" + getCurrentUserId(), {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
 };
 
 export const getNicknames = async (): Promise<string[]> => {

--- a/src/contexts/ReportContext.tsx
+++ b/src/contexts/ReportContext.tsx
@@ -1,22 +1,9 @@
-import { createContext, useContext, useMemo } from "react";
-import { Answer, MBTI } from "../@types";
-import { calcAgeGroup, groupBy } from "../common/utils";
+import { createContext, useContext } from "react";
+import { Answer, Option } from "../@types";
 
-type Group<K> = ReturnType<typeof groupBy<K, Answer>>;
-
-type Data = {
+type ReportState = {
   answer: Answer;
-  answers: Answer[];
-};
-type ReportState = Data & {
-  groups: {
-    user: {
-      mbti: Group<MBTI>;
-      region: Group<string>;
-      age: Group<string>;
-      gender: Group<string>;
-    };
-  };
+  groups: { [groupKey: string]: { [id: string]: Option[] } };
 };
 
 const ReportStateContext = createContext<ReportState | undefined>(undefined);
@@ -25,23 +12,11 @@ export const ReportContextProvider = ({
   data,
   children,
 }: {
-  data: Data;
+  data: ReportState;
   children: React.ReactNode;
 }) => {
-  const { answers } = data;
-  const groups = useMemo(
-    () => ({
-      user: {
-        mbti: groupBy(answers, (answer) => answer.user.MBTI),
-        region: groupBy(answers, (answer) => answer.user.region),
-        age: groupBy(answers, (answer) => calcAgeGroup(answer.user.birthdate)),
-        gender: groupBy(answers, (answer) => answer.user.gender),
-      },
-    }),
-    [answers]
-  );
   return (
-    <ReportStateContext.Provider value={{ ...data, groups }}>
+    <ReportStateContext.Provider value={{ ...data }}>
       {children}
     </ReportStateContext.Provider>
   );

--- a/src/contexts/ReportContext.tsx
+++ b/src/contexts/ReportContext.tsx
@@ -3,6 +3,7 @@ import { Answer, Option } from "../@types";
 
 type ReportState = {
   answer: Answer;
+  options: Option[];
   groups: { [groupKey: string]: { [id: string]: Option[] } };
 };
 

--- a/src/pages/DeleteAccount.tsx
+++ b/src/pages/DeleteAccount.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { deleteUser } from "../common/apis";
 import { useNavigate } from "react-router-dom";
+import { useAuthenticatedState } from "../contexts/AuthContext";
 
 import Header from "../components/Header";
 import Footer from "../components/Footer";
@@ -8,19 +9,21 @@ import Button from "../components/Button";
 import ModalPortal from "../components/ModalPortal";
 import Loading from "../components/Loading";
 
-import leftArrowIcon from "../assets/left_arrow.svg";
 import cryingIcon from "../assets/crying.png";
 
 const DeleteAccount = () => {
+  const { user } = useAuthenticatedState();
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
   const onDeleteUser = async () => {
     setIsLoading(true);
     try {
-      await deleteUser();
+      const token = await user.getIdToken();
+      await deleteUser(token);
     } catch (error) {}
     setIsLoading(false);
+    navigate("/login", { replace: true });
   };
 
   return (

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import useAsyncAPI from "../hooks/useAsyncAPI";
-import { getAnswers, getTodayQuestion, getUser } from "../common/apis";
+import { getMyAnswers, getTodayQuestion, getUser } from "../common/apis";
 import { useAuthenticatedState } from "../contexts/AuthContext";
 import { User } from "firebase/auth";
 import { MBTI } from "../@types";
@@ -93,8 +93,7 @@ const getHomeData = async (authUser: User) => {
 
   const question = await getTodayQuestion();
 
-  const myAnswers = await getAnswers({ user: authUser.uid, token });
-  const answers = myAnswers.status === 204 ? [] : myAnswers.data;
+  const answers = await getMyAnswers(authUser.uid, token);
   const todayAnswer = answers.filter(
     (answer) => answer.question.id === question.data.id
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -84,8 +84,10 @@ const Main = ({
 };
 
 const getHomeData = async (authUser: User) => {
+  const token = await authUser.getIdToken();
+
   const question = await getTodayQuestion();
-  const myAnswers = await getAnswers({ user: authUser.uid });
+  const myAnswers = await getAnswers({ user: authUser.uid, token });
   const isEmptyAnswers = myAnswers.status === 204;
   const answerCount = isEmptyAnswers ? 0 : myAnswers.data.length;
   const todayAnswer = isEmptyAnswers
@@ -94,7 +96,6 @@ const getHomeData = async (authUser: User) => {
         (answer) => answer.question.id === question.data.id
       );
 
-  const token = await authUser.getIdToken();
   const user = await getUser(authUser.uid, token);
   if (!user) {
     await auth.signOut();

--- a/src/pages/KakaoLogin.tsx
+++ b/src/pages/KakaoLogin.tsx
@@ -11,9 +11,8 @@ import withAuth from "../hocs/withAuth";
 
 const authorize = async (code: string) => {
   const { data } = await authKakao(code);
-  const user = await getUser(data.kakaoUser.id, data.firebaseToken);
 
-  if (user) {
+  if (data.isJoined) {
     await signInWithCustomToken(firebaseAuth, data.firebaseToken);
     return { isLoggedIn: true, auth: data };
   }

--- a/src/pages/KakaoLogin.tsx
+++ b/src/pages/KakaoLogin.tsx
@@ -11,7 +11,7 @@ import withAuth from "../hocs/withAuth";
 
 const authorize = async (code: string) => {
   const { data } = await authKakao(code);
-  const user = await getUser(data.kakaoUser.id);
+  const user = await getUser(data.kakaoUser.id, data.firebaseToken);
 
   if (user) {
     await signInWithCustomToken(firebaseAuth, data.firebaseToken);

--- a/src/pages/KakaoLogin.tsx
+++ b/src/pages/KakaoLogin.tsx
@@ -1,7 +1,7 @@
 import { Navigate } from "react-router-dom";
 import { signInWithCustomToken } from "firebase/auth";
 import { auth as firebaseAuth } from "../config";
-import { authKakao, getUser } from "../common/apis";
+import { authKakao } from "../common/apis";
 
 import Loading from "../components/Loading";
 import useAsyncAPI from "../hooks/useAsyncAPI";

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -12,12 +12,6 @@ import kakaoSymbol from "../assets/kakao.svg";
 import tightee from "../assets/tightee.svg";
 import home from "../assets/home.png";
 
-declare global {
-  interface Window {
-    Kakao: any;
-  }
-}
-
 const onLoginWithKakao = () => {
   const redirectUri = `${location.origin}/callback/kakaotalk`;
   const scope = [

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -1,5 +1,5 @@
 import { Link, Navigate, useNavigate, useParams } from "react-router-dom";
-import { getAnswer, getAnswerGroups } from "../common/apis";
+import { getAnswer, getAnswerGroups, getOptions } from "../common/apis";
 import useAsyncAPI from "../hooks/useAsyncAPI";
 import { Answer, MBTI, Option } from "../@types";
 import {
@@ -140,27 +140,19 @@ const EmptyMBTI = () => (
 
 const DetailReport = () => {
   const {
-    answer: { user, question, option },
+    answer: { user, option },
+    options,
     groups,
   } = useReportState();
 
   const mbtiData = genChartData(
     groups["user.MBTI"][user.MBTI ?? "null"],
-    question.options
+    options
   );
-  const regionData = genChartData(
-    groups["user.region"][user.region],
-    question.options
-  );
+  const regionData = genChartData(groups["user.region"][user.region], options);
   const ageGroup = calcAgeGroup(user.birthdate);
-  const ageData = genChartData(
-    groups["user.birthdate"][ageGroup],
-    question.options
-  );
-  const genderData = genChartData(
-    groups["user.gender"][user.gender],
-    question.options
-  );
+  const ageData = genChartData(groups["user.birthdate"][ageGroup], options);
+  const genderData = genChartData(groups["user.gender"][user.gender], options);
 
   return (
     <>
@@ -225,7 +217,7 @@ const DetailReport = () => {
 };
 
 const MBTIRankReport = () => {
-  const { answer, groups } = useReportState();
+  const { answer, options, groups } = useReportState();
 
   if (answer.user.MBTI === null) {
     return (
@@ -236,7 +228,7 @@ const MBTIRankReport = () => {
     );
   }
 
-  const rank = calcMBTIrank(groups["user.MBTI"], answer.question.options);
+  const rank = calcMBTIrank(groups["user.MBTI"], options);
   const myRank = rank.map((value) => value.mbti).indexOf(answer.user.MBTI) + 1;
 
   return (
@@ -261,7 +253,7 @@ const MBTIRankReport = () => {
 };
 
 const BasicReport = () => {
-  const { answer, groups } = useReportState();
+  const { answer, options, groups } = useReportState();
 
   const optionsByOptionIdMap = groups["option.id"];
   const total = Object.values(optionsByOptionIdMap).flat().length;
@@ -282,7 +274,7 @@ const BasicReport = () => {
             data={calcRatio(
               new Map(Object.entries(optionsByOptionIdMap)),
               total,
-              answer.question.options
+              options
             )}
             id={answer.option.id}
           >
@@ -317,6 +309,7 @@ const ActualReport = () => {
 
 const getMyAnswerAndAnswers = async (answerId: string) => {
   const answer = await getAnswer(answerId);
+  const options = await getOptions({ ids: answer.data.question.options });
   const groups = await getAnswerGroups({
     groups: [
       "user.MBTI",
@@ -330,6 +323,7 @@ const getMyAnswerAndAnswers = async (answerId: string) => {
 
   return {
     answer: answer.data,
+    options: options.data,
     groups,
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "typeRoots": ["./src/@types"]
+    "typeRoots": ["./src/@types"],
+    "types": ["node"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "typeRoots": ["./src/@types"]
   },
-  "include": ["src", "@types"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -795,6 +795,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
   integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
 
+"@types/node@^18.11.16":
+  version "18.11.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.16.tgz#966cae211e970199559cfbd295888fca189e49af"
+  integrity sha512-6T7P5bDkRhqRxrQtwj7vru+bWTpelgtcETAZEUSdq0YISKz8WKdoBukQLYQQ6DFHvU9JRsbFq0JH5C51X2ZdnA==
+
 "@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"


### PR DESCRIPTION
답변, 답변 목록 요청 시 인증 없이 모든 유저의 정보를 볼 수 있던 문제가 있었음.

/answers (전체 답변 목록 가져오기): 막아둠
/answers?user="" (나의 답변 가져오기): Authorization 헤더 추가, 인증 후 데이터 보내도록 함.
/answers?groups=[] (리포트 관련 비율 구하기 위해 필요): 아예 그룹화하여 유저 정보 없이 데이터 전송.
/answer/:id (답변 하나 가져오기): 민감한 유저 정보 없애고 전송.

또한 유저 관련 API도 인증 헤더를 추가함.
유저 정보 변경, 유저 삭제, 유저 정보 가져오기