### PR TITLE
fix: 파이 차트 깨져보이는 문제 수정

### DIFF
--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -77,7 +77,7 @@ const Pie = ({
     return <>ChartProvider not found.</>;
   }
 
-  const RADIUS = 21.5;
+  const RADIUS = 22.5;
   const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
   let filled = 0;
@@ -108,7 +108,9 @@ const Pie = ({
             fill="transparent"
             stroke={color}
             strokeWidth={RADIUS * 2}
-            strokeDasharray={`${strokeLength} ${spaceLength}`}
+            strokeDasharray={
+              strokeLength.toFixed(2) + " " + spaceLength.toFixed(2)
+            }
             strokeDashoffset={-offset}
             transform={`rotate(-90 50 50) translate(${y} ${x})`}
           ></circle>

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -77,7 +77,7 @@ const Pie = ({
     return <>ChartProvider not found.</>;
   }
 
-  const RADIUS = 22.5;
+  const RADIUS = 21.5;
   const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
   let filled = 0;


### PR DESCRIPTION
<img width="285" alt="image" src="https://user-images.githubusercontent.com/52340070/208700490-647051e7-f362-4173-bcab-fd814496ebe6.png">

처음에는 SVG 영역을 벗어났을 때 발생하는 문제로 추측하여 원의 크기를 줄였으나 해결되지 않음.

```css
stroke-dasharray="49.01355778498116 92.35811162655953"
```

위와 같이 소수점이 너무 길어질 경우 생기는 문제로 보임.
toFixed(2)로 소수점 제한하여 해결함.