### PR TITLE
feat: 오늘의 질문 여러 개 지원

### DIFF
--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -1,7 +1,15 @@
 import cn from "classnames";
 
-const Container = ({ children }: { children?: React.ReactNode }) => (
-  <section className="flex w-full flex-col gap-y-6">{children}</section>
+const Container = ({
+  className,
+  children,
+}: {
+  className?: cn.Argument;
+  children?: React.ReactNode;
+}) => (
+  <section className={cn("flex w-full flex-col gap-y-6", className)}>
+    {children}
+  </section>
 );
 
 const Box = ({

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-import { MBTI } from "../@types";
 import { getMBTIName } from "../common/utils";
 import { useUser } from "../contexts/UserContext";
 import { useTodayQuestions } from "../contexts/TodayQuestionContext";
@@ -39,89 +37,103 @@ const Content = ({
   </div>
 );
 
-const Main = ({
-  question,
-  answer,
-  MBTI,
-}: {
-  question: string;
-  answer: { id?: string; count: number };
-  MBTI?: MBTI;
-}) => {
+const MBTI = () => {
+  const {
+    data: { MBTI: mbti },
+  } = useUser();
+
   return (
+    <Link to="/profile">
+      <Box className="mb-0">
+        <Badge className="bg-secondary-mbti font-bold text-white">
+          나의 MBTI
+        </Badge>
+        <Content iconSrc="/images/setting.svg" alt="setting" iconWidth={20}>
+          {mbti
+            ? mbti + " - " + getMBTIName(mbti)
+            : "MBTI를 설정하면 더욱 재미있는 정보를 확인할 수 있어요 :)"}
+        </Content>
+      </Box>
+    </Link>
+  );
+};
+
+const Answer = () => {
+  const { data: myAnswers } = useMyAnswers();
+
+  return (
+    <Link to="/answer">
+      <Box>
+        <Badge className="bg-secondary-answer font-bold text-white">
+          나의 대답
+        </Badge>
+        <Content iconSrc="/images/right_arrow.svg" alt="right arrow">
+          총 {myAnswers.length}개의 질문에 대답했어요.
+        </Content>
+      </Box>
+    </Link>
+  );
+};
+
+const Question = () => {
+  const { data: todayQuestions } = useTodayQuestions();
+  const { data: myAnswers } = useMyAnswers();
+
+  if (!todayQuestions) {
+    return (
+      <Box>
+        <Badge className="bg-secondary-question font-bold text-white">
+          오늘의 질문
+        </Badge>
+        <Content iconSrc="/images/right_arrow.svg" alt="right arrow">
+          오늘의 질문이 존재하지 않아요 :(
+        </Content>
+      </Box>
+    );
+  }
+
+  const answeredQuestionIds = new Set(
+    myAnswers.map(({ question }) => question)
+  );
+  const answeredCount = todayQuestions.reduce(
+    (count, { id }) => (answeredQuestionIds.has(id) ? count + 1 : count),
+    0
+  );
+  const remaining = todayQuestions.length - answeredCount;
+  const isAllAnswered = remaining === 0;
+
+  return (
+    <Link to={isAllAnswered ? "/answer" : "/questions"}>
+      <Box>
+        <Badge className="bg-secondary-question font-bold text-white">
+          오늘의 질문
+        </Badge>
+        <Content iconSrc="/images/right_arrow.svg" alt="right arrow">
+          {isAllAnswered
+            ? "모든 질문에 대답을 완료했어요 👏"
+            : remaining + "개의 질문이 남아있어요 🐰"}
+        </Content>
+      </Box>
+    </Link>
+  );
+};
+
+const Home = () => (
+  <>
+    <Header>
+      <Header.H1>
+        <Header.Icon iconSrc="/images/home.png">타이티입니다 :)</Header.Icon>
+      </Header.H1>
+    </Header>
     <main>
       <Box.Container>
-        <Link to={answer.id ? `/answer/${answer.id}/report` : "/questions"}>
-          <Box>
-            <Badge className="bg-secondary-question font-bold text-white">
-              오늘의 질문
-            </Badge>
-            <Content iconSrc="/images/right_arrow.svg" alt="right arrow">
-              {question}
-            </Content>
-          </Box>
-        </Link>
-
-        <Link to="/answer">
-          <Box>
-            <Badge className="bg-secondary-answer font-bold text-white">
-              나의 대답
-            </Badge>
-            <Content iconSrc="/images/right_arrow.svg" alt="right arrow">
-              총 {answer?.count}개의 질문에 대답했어요.
-            </Content>
-          </Box>
-        </Link>
-
-        <Link to="/profile">
-          <Box className="mb-0">
-            <Badge className="bg-secondary-mbti font-bold text-white">
-              나의 MBTI
-            </Badge>
-            <Content iconSrc="/images/setting.svg" alt="setting" iconWidth={20}>
-              {MBTI
-                ? MBTI + " - " + getMBTIName(MBTI)
-                : "MBTI를 설정하면 더욱 재미있는 정보를 확인할 수 있어요 :)"}
-            </Content>
-          </Box>
-        </Link>
+        <Question />
+        <Answer />
+        <MBTI />
       </Box.Container>
     </main>
-  );
-};
-
-const Home = () => {
-  const user = useUser();
-  const todayQuestions = useTodayQuestions();
-  const myAnswers = useMyAnswers();
-  const todayAnswer = useMemo(
-    () =>
-      myAnswers.data.find(
-        (answer) =>
-          answer.question === (todayQuestions.data && todayQuestions.data[0].id)
-      ),
-    [myAnswers]
-  );
-
-  return (
-    <>
-      <Header>
-        <Header.H1>
-          <Header.Icon iconSrc="/images/home.png">타이티입니다 :)</Header.Icon>
-        </Header.H1>
-      </Header>
-      <Main
-        question={
-          todayQuestions.data
-            ? todayQuestions.data[0].title
-            : "오늘의 질문이 존재하지 않아요 :("
-        }
-        answer={{ id: todayAnswer?.id, count: myAnswers.data.length }}
-        MBTI={user.data.MBTI}
-      />
-      <Footer />
-    </>
-  );
-};
+    <Footer />
+  </>
+);
 
 export default Home;


### PR DESCRIPTION
❶ 홈
<img width="898" alt="image" src="https://user-images.githubusercontent.com/52340070/211347294-4b0da1e3-66c6-4f67-aec4-b600cb9a286b.png">

**전**
- 질문이 하나밖에 없었기 때문에 title을 띄움
- 답변을 했을 경우 리포트로 이동하고 아닐 경우 질문 페이지로 이동

**후**
- 답변을 하지 않은 질문 갯수 표시 (N개의 질문이 남아있어요 🐰)
- 모든 질문에 답변했을 경우 사진과 같이 '모든 질문에 대답을 완료했어요 👏' 표시
- 질문이 남아있는 경우 질문 리스트 페이지로 이동하고 아닐 경우 나의 대답 페이지로 이동

---

❷ 나의 대답

**전**
- 대답은 최신 순으로 정렬되어 내려오기 때문에 첫 번째 대답의 질문 ID가 오늘의 질문 ID와 일치하는지 확인
  - 일치할 경우 오늘의 질문에 대답하였다는 문구 표시 후 다른 대답들과 동일하게 표시
  - 일치하지 않을 경우 오늘의 질문에 대답을 유도함

**후**
- 대답한 질문의 ID들을 Set으로 만들어 오늘의 질문들이 모두 포함되어 있는지 확인
  - 포함되어 있을 경우 모든 질문에 대답하였다는 문구 표시 후 다른 대답들과 동일하게 표시 (문구만 변경됨)
  - 포함되어 있지 않은 질문들만 대답 유도