### PR TITLE
fix: 답변 후 빈 화면이 뜨는 문제 수정

### DIFF
--- a/src/pages/Answers.tsx
+++ b/src/pages/Answers.tsx
@@ -37,12 +37,12 @@ const MyAnswer = ({
   const { id, question: questionId, option: optionId } = answer;
   const { isLoading, isError, data: question } = useQuestionQuery(questionId);
 
-  const sameAnswers = groupBy(options, (option) => option).get(optionId);
-  const ratio = (sameAnswers?.length || 0) / options.length;
-
-  if (isLoading || isError || !question) {
+  if (isLoading || isError || !question || !options) {
     return <AnswerPlaceholder />;
   }
+
+  const sameAnswers = groupBy(options, (option) => option).get(optionId);
+  const ratio = (sameAnswers?.length || 0) / options.length;
 
   return (
     <Question

--- a/src/pages/QuestionList.tsx
+++ b/src/pages/QuestionList.tsx
@@ -26,6 +26,9 @@ const TodayQuestion = ({
   options: string[];
 }) => {
   if (myAnswer) {
+    if (!options) {
+      return <Skeleton.BoxLoader key={question.id} />;
+    }
     const sameAnswers = groupBy(options, (option) => option).get(
       myAnswer?.option
     );


### PR DESCRIPTION
answerGroups 쿼리가 isFetching일 때 발생하는 문제이다.

답변한 질문의 경우 전체 타이티 중 몇 퍼센트에 해당하는지 보여주기 위해 비율을 계산하는데, !isLoading && isFetching인 그룹 쿼리로 인해 다시 불러오는 중이라 존재하지 않는 데이터를 이용하여 groupBy를 수행하여 발생한 에러.

isFetching일 때 스켈레톤 UI를 표시할 경우, 다른 질문도 모두 로딩 중으로 표시되기 때문에 isAnswered && !answers일 때 표시하도록 하여  해결함. 또한 그룹 쿼리도 답변했을 경우 invalidateQueries 호출하도록 했음.