### PR TITLE
refactor: 전체 질문 가져와 사용하도록 변경

### DIFF
--- a/functions/src/questions.ts
+++ b/functions/src/questions.ts
@@ -14,21 +14,21 @@ app.get("/", async (req, res) => {
     const app = getAdminApp();
     const db = admin.firestore(app);
 
-    const { docs } = await db
-      .collection("questions")
-      .where("createdAt", "==", date)
-      .get();
+    const query = date
+      ? db.collection("questions").where("createdAt", "==", date)
+      : db.collection("questions");
 
-    if (docs.length === 0) {
-      return res
-        .status(204)
-        .json({ code: 204, message: "오늘의 질문이 존재하지 않습니다." });
-    }
-
+    const { docs } = await query.get();
     const questions = docs.map((doc) => ({
       ...(doc.data() as Question),
       id: doc.id,
     }));
+
+    if (questions.length === 0) {
+      return res
+        .status(204)
+        .json({ code: 204, message: "질문이 존재하지 않습니다." });
+    }
 
     return res.status(200).json(questions);
   } catch (error) {

--- a/src/hooks/queries/useQuestionsQuery.ts
+++ b/src/hooks/queries/useQuestionsQuery.ts
@@ -2,11 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { getQuestions } from "../../common/apis";
 
 export const useQuestionsQuery = (
-  keys: string[],
-  params: Parameters<typeof getQuestions>[0]
+  keys?: string[],
+  params?: Parameters<typeof getQuestions>[0]
 ) => {
   return useQuery({
-    queryKey: ["questions", ...keys],
+    queryKey: ["questions", ...(keys || [])],
     queryFn: () => getQuestions(params),
     select: (res) => res.data,
   });

--- a/src/hooks/queries/useTodayQuestionsQuery.ts
+++ b/src/hooks/queries/useTodayQuestionsQuery.ts
@@ -1,0 +1,16 @@
+import { getLocalTime } from "../../common/utils";
+import { useQuestionsQuery } from "./useQuestionsQuery";
+
+export const useTodayQuestionsQuery = () => {
+  const questions = useQuestionsQuery();
+  const today = getLocalTime().format("YYYYMMDD");
+
+  if (questions.data) {
+    return {
+      ...questions,
+      data: questions.data.filter((question) => question.createdAt === today),
+    };
+  }
+
+  return questions;
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,10 @@
 import { Link } from "react-router-dom";
 
-import { getLocalTime, getMBTIName } from "../common/utils";
+import { getMBTIName } from "../common/utils";
 import { useUserQuery } from "../hooks/queries/useUserQuery";
 import { useAuthenticatedState } from "../contexts/AuthContext";
 import { useMyAnswersQuery } from "../hooks/queries/useMyAnswersQuery";
+import { useTodayQuestionsQuery } from "../hooks/queries/useTodayQuestionsQuery";
 
 import Header from "../components/Header";
 import Badge from "../components/Badge";
@@ -12,7 +13,6 @@ import Img from "../components/Img";
 import Notice from "../components/Notice";
 import ErrorView from "../components/ErrorView";
 import Skeleton from "../components/Skeleton";
-import { useQuestionsQuery } from "../hooks/queries/useQuestionsQuery";
 
 const Footer = () => (
   <Notice
@@ -102,8 +102,7 @@ const Answer = ({ uid }: { uid: string }) => {
 };
 
 const Question = ({ uid }: { uid: string }) => {
-  const today = getLocalTime().format("YYYYMMDD");
-  const todayQuestions = useQuestionsQuery([today], { date: today });
+  const todayQuestions = useTodayQuestionsQuery();
   const myAnswers = useMyAnswersQuery(uid);
 
   if (todayQuestions.isLoading || myAnswers.isLoading) {

--- a/src/pages/QuestionList.tsx
+++ b/src/pages/QuestionList.tsx
@@ -3,7 +3,7 @@ import { Answer, Question as QuestionType } from "../@types";
 import { URL_CS } from "../common/constants";
 import { useMyAnswersQuery } from "../hooks/queries/useMyAnswersQuery";
 import { useAnswerGroupsQuery } from "../hooks/queries/useAnswerGroupsQuery";
-import { useQuestionsQuery } from "../hooks/queries/useQuestionsQuery";
+import { useTodayQuestionsQuery } from "../hooks/queries/useTodayQuestionsQuery";
 import { auth } from "../config";
 
 import Box from "../components/Box";
@@ -67,8 +67,7 @@ const AlreadyAnswered = () => (
 
 const Main = () => {
   const groups = useAnswerGroupsQuery(["question"]);
-  const today = getLocalTime().format("YYYYMMDD");
-  const questions = useQuestionsQuery([today], { date: today });
+  const questions = useTodayQuestionsQuery();
   const myAnswers = useMyAnswersQuery(auth.currentUser?.uid);
 
   if (groups.isLoading || questions.isLoading || myAnswers.isLoading) {


### PR DESCRIPTION
- 나의 대답 페이지에서 개별로 질문 정보를 가져올 때 동작이 비효율적임.
- 오늘의 질문을 따로 가져오고 있었는데 위 문제를 해결하기 위해 전체 질문 목록을 가져오면서 필터링하여 사용하도록 변경함.